### PR TITLE
2024/07/30 - version: 0.5.3+23

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,60 @@ samples, guidance on mobile development, and a full API reference.
 
 # ChangeLog
 
+## 2024/07/30 - version: 0.5.3+23
+
+This commit introduces a range of updates and new functionalities across multiple files:
+
+1. `lib/components/dialogs/simple_question.dart`
+   - New file: Added `SimpleQuestionDialog` widget for displaying simple question dialogs with Yes/No or Confirm/Cancel options.
+
+2. `lib/features/address/address_controller.dart`
+   - Imported `dart:developer`.
+   - Added `AddressState` management.
+   - Introduced `selectesAddresId`, `_changeState`, and `moveAdsAddressAndRemove` methods for better address handling.
+
+3. `lib/features/address/address_screen.dart`
+   - Imported `dart:developer` and `state_error_message.dart`.
+   - Updated `_removeAddress` to handle advertisements associated with the address.
+   - Added `AnimatedBuilder` for managing loading and error states.
+   - Included `DestinyAddressDialog` for handling the destination address when removing an address.
+
+4. `lib/features/my_data/my_data_state.dart`
+   - Renamed file to `lib/features/address/address_state.dart` to be consistent with the new address state management.
+
+5. `lib/features/address/widgets/destiny_address_dialog.dart`
+   - New file: Added `DestinyAddressDialog` widget for selecting a destination address when removing an address with associated advertisements.
+
+6. `lib/features/my_ads/my_ads_screen.dart`
+   - Added `floatingActionButton` for adding new advertisements.
+   - Introduced `_addNewAdvert` method to navigate to the `EditAdvertScreen`.
+
+7. `lib/features/my_data/my_data_controller.dart`
+   - Removed `MyDataState` management to simplify the controller.
+   - Removed `_changeState` method.
+
+8. `lib/features/my_data/my_data_screen.dart`
+   - Added `backScreen` method to handle unsaved changes.
+   - Refactored the screen layout to include `SimpleQuestionDialog` for unsaved changes.
+
+9. `lib/manager/address_manager.dart`
+   - Added methods `deleteByName`, `deleteById`, and `getAddressIdFromName` for better address management.
+
+10. `lib/repository/address_repository.dart`
+    - Updated `delete` method to accept `addressId` instead of `address`.
+    - Added `moveAdsAddressTo` method for moving advertisements to another address.
+    - Added `adsInAddress` method to retrieve advertisements associated with a specific address.
+
+11. `lib/repository/advert_repository.dart`
+    - Updated `delete` method to accept `adId` instead of `ad`.
+    - Added `moveAdsAddressTo` and `adsInAddress` methods to support address management.
+
+12. `pubspec.yaml`
+    - Updated version to `0.5.3+23`.
+
+These changes collectively enhance the address management functionality, introduce new dialog widgets for better user interaction, and update the repository methods to handle advertisement associations with addresses.
+
+
 ## 2024/07/30 - version: 0.5.2+22
 
 This commit introduces several enhancements and fixes across multiple files:

--- a/lib/components/dialogs/simple_question.dart
+++ b/lib/components/dialogs/simple_question.dart
@@ -1,0 +1,88 @@
+// Copyright (C) 2024 Rudson Alves
+//
+// This file is part of xlo_parse_server.
+//
+// xlo_parse_server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlo_parse_server is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlo_parse_server.  If not, see <https://www.gnu.org/licenses/>.
+
+// Copyright (C) 2024 Rudson Alves
+//
+// This file is part of xlo_parse_server.
+//
+// xlo_parse_server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlo_parse_server is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlo_parse_server.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+
+enum SQMessageType { yesNo, confirmCancel }
+
+class SimpleQuestionDialog extends StatelessWidget {
+  final String title;
+  final String message;
+  final SQMessageType type;
+
+  const SimpleQuestionDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    this.type = SQMessageType.yesNo,
+  });
+
+  static Future<bool> open(
+    BuildContext context, {
+    required String title,
+    required String message,
+    SQMessageType? type,
+  }) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => SimpleQuestionDialog(
+            title: title,
+            message: message,
+            type: type ?? SQMessageType.yesNo,
+          ),
+        ) ??
+        false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return AlertDialog(
+      title: Text(title),
+      backgroundColor: colorScheme.onSecondary,
+      content: Text(message),
+      actions: [
+        FilledButton.tonal(
+          onPressed: () => Navigator.pop(context, true),
+          child: Text(type == SQMessageType.yesNo ? 'Sim' : 'Confirmar'),
+        ),
+        FilledButton.tonal(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text(type == SQMessageType.yesNo ? 'Não' : 'Cancelar'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/address/address_state.dart
+++ b/lib/features/address/address_state.dart
@@ -15,12 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with xlo_parse_server.  If not, see <https://www.gnu.org/licenses/>.
 
-abstract class MyDataState {}
+abstract class AddressState {}
 
-class MyDataStateInitial extends MyDataState {}
+class AddressStateInitial extends AddressState {}
 
-class MyDataStateLoading extends MyDataState {}
+class AddressStateLoading extends AddressState {}
 
-class MyDataStateSuccess extends MyDataState {}
+class AddressStateSuccess extends AddressState {}
 
-class MyDataStateError extends MyDataState {}
+class AddressStateError extends AddressState {}

--- a/lib/features/address/widgets/destiny_address_dialog.dart
+++ b/lib/features/address/widgets/destiny_address_dialog.dart
@@ -1,0 +1,143 @@
+// Copyright (C) 2024 Rudson Alves
+//
+// This file is part of xlo_parse_server.
+//
+// xlo_parse_server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// xlo_parse_server is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with xlo_parse_server.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:xlo_mobx/common/theme/app_text_style.dart';
+import 'package:xlo_mobx/features/filters/widgets/text_title.dart';
+
+import '../../../get_it.dart';
+import '../../../manager/address_manager.dart';
+
+class DestinyAddressDialog extends StatefulWidget {
+  final List<String> addressNames;
+  final String addressRemoveName;
+  final int adsListLength;
+
+  const DestinyAddressDialog({
+    super.key,
+    required this.addressNames,
+    required this.addressRemoveName,
+    required this.adsListLength,
+  });
+
+  static Future<String?> open(
+    BuildContext context, {
+    required List<String> addressNames,
+    required String addressRemoveName,
+    required int adsListLength,
+  }) async {
+    return await showDialog<String?>(
+      context: context,
+      builder: (_) => DestinyAddressDialog(
+        addressNames: addressNames,
+        addressRemoveName: addressRemoveName,
+        adsListLength: adsListLength,
+      ),
+    );
+  }
+
+  @override
+  State<DestinyAddressDialog> createState() => _DestinyAddressDialogState();
+}
+
+class _DestinyAddressDialogState extends State<DestinyAddressDialog> {
+  final addressManager = getIt<AddressManager>();
+  String selected = '';
+  late final int adsListLength;
+  late final String s;
+  late final List<String> avaliableAddress;
+
+  @override
+  void initState() {
+    super.initState();
+    adsListLength = widget.adsListLength;
+    s = adsListLength > 1 ? 's' : '';
+
+    avaliableAddress = addressManager.addressNames
+        .where((name) => name != widget.addressRemoveName)
+        .toList();
+    selected = avaliableAddress[0];
+  }
+
+  List<String> dialogTexts() {
+    return [
+      'O endereço "${widget.addressRemoveName.toUpperCase()}" possui'
+          ' $adsListLength anúcio$s vinculado$s.',
+      'Para removê-lo é necessário Mover este$s anúcio$s para'
+          ' outro endereço.',
+      'Selecione um endereço destino para continuar, ou cancele a operação.',
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Dialog(
+      backgroundColor: colorScheme.onSecondary,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 12, right: 12, bottom: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Center(child: TextTitle('Atenção')),
+            const SizedBox(height: 8),
+            ...dialogTexts().map(
+              (t) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  t,
+                  style: AppTextStyle.font16,
+                ),
+              ),
+            ),
+            DropdownButton<String>(
+              value: selected,
+              items: avaliableAddress
+                  .map(
+                    (e) => DropdownMenuItem(
+                      value: e,
+                      child: Text(e),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                if (value != null) {
+                  selected = value;
+                  setState(() {});
+                }
+              },
+            ),
+            ButtonBar(
+              children: [
+                FilledButton.tonal(
+                  onPressed: () => Navigator.pop(context, selected),
+                  child: const Text('Aplicar'),
+                ),
+                FilledButton.tonal(
+                  onPressed: () => Navigator.pop(context, null),
+                  child: const Text('Cancelar'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/my_ads/my_ads_screen.dart
+++ b/lib/features/my_ads/my_ads_screen.dart
@@ -95,6 +95,11 @@ class _MyAdsScreenState extends State<MyAdsScreen> {
     }
   }
 
+  Future<void> _addNewAdvert() async {
+    await Navigator.pushNamed(context, EditAdvertScreen.routeName);
+    ctrl.getAds();
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -112,6 +117,12 @@ class _MyAdsScreenState extends State<MyAdsScreen> {
             onPressed: _backPage,
           ),
           bottom: MyTabBar(setProductStatus: ctrl.setProductStatus),
+        ),
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: _addNewAdvert,
+          backgroundColor: colorScheme.primaryContainer.withOpacity(0.75),
+          icon: const Icon(Icons.camera),
+          label: const Text('Adicionar anúncio'),
         ),
         body: ListenableBuilder(
           listenable: ctrl,

--- a/lib/features/my_data/my_data_controller.dart
+++ b/lib/features/my_data/my_data_controller.dart
@@ -27,13 +27,8 @@ import '../../components/custon_field_controllers/masked_text_controller.dart';
 import '../../get_it.dart';
 import '../../manager/address_manager.dart';
 import '../../repository/user_repository.dart';
-import 'my_data_state.dart';
 
 class MyDataController extends ChangeNotifier {
-  MyDataState _state = MyDataStateInitial();
-
-  MyDataState get state => _state;
-
   final formKey = GlobalKey<FormState>();
   final nameController = TextEditingController();
   final phoneController = MaskedTextController(mask: '(##) ####-#####');
@@ -59,11 +54,6 @@ class MyDataController extends ChangeNotifier {
     super.dispose();
   }
 
-  void _changeState(MyDataState newState) {
-    _state = newState;
-    notifyListeners();
-  }
-
   void init() {
     nameController.text = user.name ?? '';
     phoneController.text = user.phone ?? '';
@@ -86,7 +76,6 @@ class MyDataController extends ChangeNotifier {
 
   Future<void> updateUserData() async {
     try {
-      _changeState(MyDataStateLoading());
       final newName = nameController.text.trim();
       final newPhone = phoneController.text;
       final newPass = passwordController.text.trim();
@@ -107,9 +96,7 @@ class MyDataController extends ChangeNotifier {
         user.name = newUser.name ?? user.name;
         user.phone = newUser.phone ?? user.phone;
       }
-      _changeState(MyDataStateSuccess());
     } catch (err) {
-      _changeState(MyDataStateError());
       log(err.toString());
     }
   }

--- a/lib/manager/address_manager.dart
+++ b/lib/manager/address_manager.dart
@@ -56,11 +56,19 @@ class AddressManager {
   /// Deletes the address with the given name.
   ///
   /// [name] - The name of the address to be deleted.
-  Future<void> delete(String name) async {
+  Future<void> deleteByName(String name) async {
     final index = _indexWhereName(name);
     if (index != -1) {
       final address = _addresses[index];
-      await AddressRepository.delete(address);
+      await AddressRepository.delete(address.id!);
+      _addresses.removeAt(index);
+    }
+  }
+
+  Future<void> deleteById(String addressId) async {
+    final index = _indexWhereId(addressId);
+    if (index != -1) {
+      await AddressRepository.delete(addressId);
       _addresses.removeAt(index);
     }
   }
@@ -122,5 +130,13 @@ class AddressManager {
     return _addresses.indexWhere(
       (addr) => addr.id == id,
     );
+  }
+
+  String? getAddressIdFromName(String name) {
+    try {
+      return _addresses.firstWhere((a) => a.name == name).id!;
+    } catch (err) {
+      return null;
+    }
   }
 }

--- a/lib/repository/address_repository.dart
+++ b/lib/repository/address_repository.dart
@@ -76,16 +76,12 @@ class AddressRepository {
 
   /// Deletes an address from the Parse Server.
   ///
-  /// [address] - The address model to delete.
+  /// [addressId] - The address model to delete.
   /// Returns `true` if successful, otherwise returns `false`.
-  static Future<bool> delete(AddressModel address) async {
+  static Future<bool> delete(String addressId) async {
     try {
-      if (address.id == null) {
-        throw Exception('address ID is required to delete the address');
-      }
-
       final parseAddress = ParseObject(keyAddressTable);
-      parseAddress.objectId = address.id!;
+      parseAddress.objectId = addressId;
 
       final response = await parseAddress.delete();
       if (!response.success) {
@@ -95,7 +91,7 @@ class AddressRepository {
     } catch (err) {
       final message = 'AddressRepository.delete: $err';
       log(message);
-      return false;
+      throw Exception(message);
     }
   }
 
@@ -116,8 +112,7 @@ class AddressRepository {
       }
 
       final queryBuilder = QueryBuilder<ParseObject>(parseAddress)
-        ..whereEqualTo(keyAddressOwner,
-            parseUser); // FIXME: check if is need a .toPointer() here!
+        ..whereEqualTo(keyAddressOwner, parseUser.toPointer());
 
       final response = await queryBuilder.query();
       if (!response.success) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: xlo_mobx
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.5.2+22
+version: 0.5.3+23
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
This commit introduces a range of updates and new functionalities across multiple files:

1. `lib/components/dialogs/simple_question.dart`
   - New file: Added `SimpleQuestionDialog` widget for displaying simple question dialogs with Yes/No or Confirm/Cancel options.

2. `lib/features/address/address_controller.dart`
   - Imported `dart:developer`.
   - Added `AddressState` management.
   - Introduced `selectesAddresId`, `_changeState`, and `moveAdsAddressAndRemove` methods for better address handling.

3. `lib/features/address/address_screen.dart`
   - Imported `dart:developer` and `state_error_message.dart`.
   - Updated `_removeAddress` to handle advertisements associated with the address.
   - Added `AnimatedBuilder` for managing loading and error states.
   - Included `DestinyAddressDialog` for handling the destination address when removing an address.

4. `lib/features/my_data/my_data_state.dart`
   - Renamed file to `lib/features/address/address_state.dart` to be consistent with the new address state management.

5. `lib/features/address/widgets/destiny_address_dialog.dart`
   - New file: Added `DestinyAddressDialog` widget for selecting a destination address when removing an address with associated advertisements.

6. `lib/features/my_ads/my_ads_screen.dart`
   - Added `floatingActionButton` for adding new advertisements.
   - Introduced `_addNewAdvert` method to navigate to the `EditAdvertScreen`.

7. `lib/features/my_data/my_data_controller.dart`
   - Removed `MyDataState` management to simplify the controller.
   - Removed `_changeState` method.

8. `lib/features/my_data/my_data_screen.dart`
   - Added `backScreen` method to handle unsaved changes.
   - Refactored the screen layout to include `SimpleQuestionDialog` for unsaved changes.

9. `lib/manager/address_manager.dart`
   - Added methods `deleteByName`, `deleteById`, and `getAddressIdFromName` for better address management.

10. `lib/repository/address_repository.dart`
    - Updated `delete` method to accept `addressId` instead of `address`. - Added `moveAdsAddressTo` method for moving advertisements to another address. - Added `adsInAddress` method to retrieve advertisements associated with a specific address.

11. `lib/repository/advert_repository.dart` - Updated `delete` method to accept `adId` instead of `ad`. - Added `moveAdsAddressTo` and `adsInAddress` methods to support address management.

12. `pubspec.yaml` - Updated version to `0.5.3+23`.

These changes collectively enhance the address management functionality, introduce new dialog widgets for better user interaction, and update the repository methods to handle advertisement associations with addresses.